### PR TITLE
Subtitle label showing

### DIFF
--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -216,7 +216,7 @@
             
             <control type="button" id="9001">
                 <description>Subs Download</description>
-                <label>33003</label>
+                <label></label>
                 <posy>8</posy>
                 <width>32</width>
                 <height>32</height>


### PR DESCRIPTION
Hi!

It seems you forgot to fix the subtitle label which shows on top of the download subtitle button in the video osd, when you fixed all the other buttons that are represented by icons.

This pull request fixes that button as well.

Kind regards,
-Steven
