### PR TITLE
Music Hub: "Files" button not working

### DIFF
--- a/1080i/Includes_Hub.xml
+++ b/1080i/Includes_Hub.xml
@@ -293,7 +293,7 @@
         
         <item id="14">
             <label>1214</label>
-            <onclick>SendClick(502,5)</onclick>
+            <onclick>ActivateWindow(Music,Files,return)</onclick>
             <icon>special://skin/extras/icons/files.png</icon>
             <property name="Color">1</property>
         </item>


### PR DESCRIPTION
Files button doesn't work in the Music hub. Noticed it because I like updating my folders manually instead of going HAM with the "Update" button beneath the "Files" button. 

Changed the click event so it navigates to Music,Files.
