### PR TITLE
Inverse info list and media info

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -24,8 +24,10 @@
     <include file="View_55_Banner.xml" />
     <include file="View_56_BigList.xml" />
     <include file="View_57_InfoList.xml" />
+    <include file="View_577_InfoList.xml" />
     <include file="View_58_BannerList.xml" />
     <include file="View_59_MediaInfo3.xml" />
+    <include file="View_599_MediaInfo3.xml" />
     <include file="View_PVR.xml" />
 
     <include name="HiddenButton">

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -449,6 +449,8 @@
             <include condition="Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyVideoPlaylist.xml)">View_57_InfoList</include>
             <include condition="Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyVideoPlaylist.xml)">View_58_BannerList</include>
             <include condition="Window.IsVisible(MyVideoNav.xml)">View_59_MediaInfo3</include>
+            <include condition="Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyVideoPlaylist.xml)">View_577_InfoList</include>
+            <include condition="Window.IsVisible(MyVideoNav.xml)">View_599_MediaInfo3</include>
         </control>
         <include>NextAiredRSS</include>
     </include>

--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -14,7 +14,7 @@
         <value condition="stringcompare(ListItem.Label,$LOCALIZE[21452])">DefaultAddSource.png</value>
         <value condition="!IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!IsEmpty(ListItem.Art(season.poster))">$INFO[ListItem.Art(season.poster)]</value>
-        <value condition="!IsEmpty(ListItem.Art(tvshow.poster)) + [Control.IsVisible(57) | Control.IsVisible(59)]">$INFO[ListItem.Art(tvshow.poster)]</value>
+        <value condition="!IsEmpty(ListItem.Art(tvshow.poster)) + [Control.IsVisible(57) | Control.IsVisible(59) | Control.IsVisible(577)| Control.IsVisible(599)]">$INFO[ListItem.Art(tvshow.poster)]</value>
         <value>$INFO[ListItem.Icon]</value>
     </variable>
     <variable name="FanartImage">
@@ -49,15 +49,15 @@
     
     <variable name="WatchedImage">
         <value condition="ListItem.IsPlaying  + Window.IsVisible(MyPVR.xml)">overlay/OverlayPlaying.png</value>
-        <value condition="ListItem.IsPlaying  + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59)]">overlay/OverlayPlaying.png</value>
+        <value condition="ListItem.IsPlaying  + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59) | Control.IsVisible(577)| Control.IsVisible(599)]">overlay/OverlayPlaying.png</value>
         <value condition="ListItem.IsPlaying">overlay/OverlayPlaying-List.png</value>
         
         <value condition="stringcompare(ListItem.Overlay,OverlayWatched.png) + Window.IsVisible(MyPVR.xml)">overlay/OverlayWatched.png</value>
-        <value condition="stringcompare(ListItem.Overlay,OverlayWatched.png) + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59)]">overlay/OverlayWatched.png</value>
+        <value condition="stringcompare(ListItem.Overlay,OverlayWatched.png) + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59) | Control.IsVisible(577)| Control.IsVisible(599)]">overlay/OverlayWatched.png</value>
         <value condition="stringcompare(ListItem.Overlay,OverlayWatched.png)">overlay/OverlayWatched-List.png</value>
         
         <value condition="stringcompare(ListItem.Overlay,OverlayUnwatched.png) + Window.IsVisible(MyPVR.xml)">noop</value>
-        <value condition="[stringcompare(ListItem.Overlay,OverlayUnwatched.png) | Container.Content(songs)] + !Control.IsVisible(51) + !Control.IsVisible(52) + !Control.IsVisible(54) + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59)]">overlay/OverlayEmpty.png</value>
+        <value condition="[stringcompare(ListItem.Overlay,OverlayUnwatched.png) | Container.Content(songs)] + !Control.IsVisible(51) + !Control.IsVisible(52) + !Control.IsVisible(54) + ![Control.IsVisible(50) | Control.IsVisible(55) | Control.IsVisible(57) | Control.IsVisible(59) | Control.IsVisible(577)| Control.IsVisible(599)]">overlay/OverlayEmpty.png</value>
         <value condition="[stringcompare(ListItem.Overlay,OverlayUnwatched.png) | Container.Content(songs)] + !Control.IsVisible(51) + !Control.IsVisible(52) + !Control.IsVisible(54)">overlay/OverlayEmpty-List.png</value>
     </variable>
     

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -4,7 +4,7 @@
     <allowoverlay>yes</allowoverlay>
     <background>0</background>
     <defaultcontrol always="true">50</defaultcontrol>
-    <views>50,51,500,53,54,55,56,57,58,59</views>
+    <views>50,51,500,53,54,55,56,57,577,58,59,599</views>
     <onload condition="Skin.HasSetting(rss.tvnextaired)">RunScript(script.tv.show.next.aired,backend=True)</onload>
     <onload condition="Skin.HasSetting(ActivateTvTunes) + System.HasAddon(script.tvtunes)">XBMC.RunScript(script.tvtunes,backend=True)</onload>
     <controls>
@@ -22,7 +22,7 @@
             <posx>92</posx>
             <width>48</width>
             <height>48</height>
-            <onclick>SetProperty(librarynode,$INFO[Container.FolderPath],home)z</onclick>
+            <onclick>SetProperty(librarynode,$INFO[Container.FolderPath],home)</onclick>
             <onclick>Back</onclick>
             <texturenofocus flipx="true">common/right-arrow.png</texturenofocus>
             <texturefocus flipx="true">common/right-arrow.png</texturefocus>
@@ -35,7 +35,7 @@
             <include>DialogVisibility</include>
             <visible>!Window.IsActive(DialogContentSettings.xml)</visible>
             <visible>!stringcompare(Window(home).Property(previoushub),home)</visible>
-            <visible>Control.IsVisible(59) | Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(55) | Control.IsVisible(56) | Control.IsVisible(57) | Control.IsVisible(58)</visible>
+            <visible>Control.IsVisible(59) | Control.IsVisible(50) | Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(55) | Control.IsVisible(56) | Control.IsVisible(57) | Control.IsVisible(58) | Control.IsVisible(61) | Control.IsVisible(62)</visible>
             <visible>!Window.IsActive(movieinformation)</visible>
             <animation effect="slide" end="horznegpad" start="0" time="200" condition="ControlGroup(9000).HasFocus() | Window.IsActive(DialogContextMenu.xml)">Conditional</animation>
         </control>
@@ -141,7 +141,7 @@
                 <control type="radiobutton" id="9010">
                     <include>DefNavMenuButton</include>
                     <onclick>Skin.ToggleSetting(list.highlight)</onclick>
-                    <visible>Control.IsVisible(50) | Control.IsVisible(57) | Control.IsVisible(58) | Control.IsVisible(59)</visible>
+                    <visible>Control.IsVisible(50) | Control.IsVisible(57) | Control.IsVisible(58) | Control.IsVisible(59) | Control.IsVisible(577) | Control.IsVisible(599)</visible>
                     <label>31279</label>
                     <selected>Skin.HasSetting(list.highlight)</selected>
                 </control>

--- a/1080i/View_577_InfoList.xml
+++ b/1080i/View_577_InfoList.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Foundation -->
+<includes>
+    <constant name="infolistw">1448</constant>
+    <constant name="infolistx">0</constant>
+    <include name="577ListContent">
+        <control type="group">
+            <visible>Container.Content(movies) | Container.Content(episodes) | Container.Content(songs) | Container.Content(seasons) | Container.Content(tvshows)</visible>
+            
+            <control type="group">
+                <posx>10</posx>
+                <posy>8</posy>
+                <include>WatchedImage</include>
+                <animation effect="fade" start="100" end="50" condition="true">Conditional</animation>
+            </control>
+            <control type="label">
+                <posx>64</posx>
+                <width>900</width>
+                <font>Font-Button</font>
+                <label>$VAR[VARLabel]</label>
+            </control>
+        </control>
+        <control type="label">
+            <posx>30</posx>
+            <width>900</width>
+            <font>Font-Button</font>
+            <label>$VAR[VARLabel]</label>
+            <visible>!Container.Content(movies) + !Container.Content(episodes) + !Container.Content(songs) + !Container.Content(seasons) + !Container.Content(tvshows)</visible>
+        </control>
+        <control type="label">
+            <posx>30r</posx>
+            <width>900</width>
+            <font>Font-ListInfo-Small</font>
+            <align>right</align>
+            <label>$INFO[ListItem.Label2]</label>
+        </control>
+    </include>
+    <include name="View_577_InfoList">
+    
+        <description>List View (id=577)</description>
+        <control type="group">
+            <visible>Control.IsVisible(577)</visible>
+            <include>Animation.ViewChange</include>     
+            <include>DefSideLabel</include> 
+              
+            <control type="group">
+                <posx>listx</posx>
+                <posy>listy</posy>
+                <control type="group">
+                    <posy>360</posy>
+                    <control type="image">
+                        <width>globalw</width>
+                        <height>335</height>
+                        <texture border="5" colordiffuse="PosterBorder">common/border-inner.png</texture>
+                    </control>
+                    <control type="group">
+                        <posx>870</posx>
+                        <control type="image">
+                            <posx>globalpad</posx>
+                            <posy>globalpad</posy>
+                            <width>558</width>
+                            <height>315</height>
+                            <texture>$VAR[FanartImage]</texture>
+                            <aspectratio>scale</aspectratio>
+                        </control>
+                    </control>
+                    <control type="grouplist">
+                        <orientation>vertical</orientation>
+                        <posx>20</posx>
+                        <posy>16</posy>
+                        <width>830</width>
+                        <height>312</height>
+                        <itemgap>4</itemgap>
+                        <control type="label">
+                            <width>830</width>
+                            <height>44</height>
+                            <aligny>top</aligny>
+                            <label>$INFO[ListItem.Label]</label>
+                            <font>Font-ListHeader</font>
+                        </control>
+                        <control type="label">
+                            <width>830</width>
+                            <height>46</height>
+                            <aligny>top</aligny>
+                            <label>$VAR[VARLabel3]</label>
+                            <font>Font-ListInfo-Small</font>
+                        </control>
+                        <control type="textbox">
+                            <width>830</width>
+                            <height>200</height>
+                            <label>$INFO[ListItem.Plot]</label>
+                            <font>Font-ListInfo</font>
+                            <align>justify</align>
+                        </control>
+                    </control>
+                </control>
+                <control type="group">
+                    <posy>0</posy>
+					
+                    <control type="image">
+                        <posx>infolistx</posx>
+                        <posy>0</posy>
+                        <width>infolistw</width>
+                        <height>345</height>
+                        <texture border="5" colordiffuse="PosterBorder">common/border-inner.png</texture>
+                        <visible>!Skin.HasSetting(list.highlight)</visible>
+                    </control>
+                
+                    
+                    <control type="list" id="577">
+                        <posx>infolistx</posx>
+                        <width>infolistw</width>
+                        <height>345</height>
+                        <onleft>61</onleft>
+                        <onright>9000</onright>
+                        <onup>577</onup>
+                        <ondown>577</ondown>
+                        <movement>2</movement>
+                        <focusposition>2</focusposition>
+                        <include>DefOnBack</include>
+                        <pagecontrol>61</pagecontrol>
+                        <viewtype label="31280">list</viewtype>
+                        <scrolltime tween="quadratic">400</scrolltime>
+
+                        <itemlayout width="infolistw" height="69">
+                            <control type="group">
+                                <include>577ListContent</include>
+                            </control>
+            
+
+                        </itemlayout>
+
+                        <focusedlayout width="infolistw" height="69">
+                            <control type="group">
+                                <control type="group">
+                                    <visible>Control.HasFocus(577)</visible>
+                                 
+                                    <control type="group">
+                                        <visible>Skin.HasSetting(list.highlight)</visible>
+                                        <control type="image">
+                                            <height>listh</height>
+                                            <width>infolistw</width>
+                                            <texture border="12" flipx="false" colordiffuse="PosterBorder">common/border-inner.png</texture>
+                                        </control>
+                                        <control type="image">
+                                            <height>listh</height>
+                                            <width>8</width>
+                                            <texture flipx="false" colordiffuse="PosterHighlight">common/white.png</texture>
+                                        </control>
+                                    </control>
+                                    <control type="image">
+                                        <visible>!Skin.HasSetting(list.highlight)</visible>
+                                        <height>listh</height>
+                                        <width>infolistw</width>
+                                        <texture border="12" flipx="false" colordiffuse="PosterHighlight">common/white.png</texture>
+                                    </control>
+                                    <control type="group">
+                                        <visible>Container.Content(movies) | Container.Content(episodes) | Container.Content(songs) | Container.Content(seasons) | Container.Content(tvshows)</visible>
+                                        <control type="group">
+                                            <posx>10</posx>
+                                            <posy>8</posy>
+                                            <include>WatchedImage</include>
+                                        </control>
+                                        <control type="label">
+                                            <posx>64</posx>
+                                            <width>900</width>
+                                            <textcolor>Selected</textcolor>
+                                            <font>Font-Button</font>
+                                            <label>$VAR[VARLabel]</label>
+                                        </control>
+                                    </control>
+                                    <control type="label">
+                                        <posx>30</posx>
+                                        <width>900</width>
+                                        <font>Font-Button</font>
+                                        <textcolor>Selected</textcolor>
+                                        <label>$VAR[VARLabel]</label>
+                                        <visible>!Container.Content(movies) + !Container.Content(episodes) + !Container.Content(songs) + !Container.Content(seasons) + !Container.Content(tvshows)</visible>
+                                    </control>
+                                    <control type="label">
+                                        <posx>30r</posx>
+                                        <width>900</width>
+                                        <textcolor>Selected</textcolor>
+                                        <font>Font-ListInfo-Small</font>
+                                        <align>right</align>
+                                        <label>$INFO[ListItem.Label2]</label>
+                                    </control>
+                                    
+                                </control>
+                                <control type="group">
+                                    <visible>!Control.HasFocus(577)</visible>
+                                    <include>577ListContent</include>
+                                </control>
+                            </control>
+                        </focusedlayout>
+
+                    </control>
+                </control>
+                <control type="scrollbar" id="61">
+                    <posx>infolistx</posx>
+                    <posy>0</posy>
+                    <height>345</height>
+                    <include>DefScrollBarMove</include>
+                    <animation effect="fade" start="100" end="0" time="100" condition="!Control.HasFocus(61)">Conditional</animation>
+                    <animation effect="fade" start="100" end="0" condition="[!IntegerGreaterThan(Container.NumPages,1) + !Control.HasFocus(61)] | ControlGroup(9000).HasFocus()">Conditional</animation>
+                </control>    
+            </control>
+        </control>
+
+    </include>
+
+</includes>

--- a/1080i/View_599_MediaInfo3.xml
+++ b/1080i/View_599_MediaInfo3.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Foundation -->
+<includes>
+    <include name="599ListContent">
+        <control type="label">
+            <left>25</left>
+            <right>75</right>
+            <font>Font-ListInfo</font>
+            <label>$VAR[VARLabel]</label>
+        </control>
+        <control type="group">
+            <posx>56r</posx>
+            <posy>8</posy>
+            <include>WatchedImage</include>
+        </control>
+    </include>
+
+    <include name="View_599_MediaInfo3">
+    
+        <description>List View (id=599)</description>
+        <control type="group">
+            <visible>Control.IsVisible(599)</visible>
+            <include>Animation.ViewChange</include>     
+            <include>DefSideLabel</include> 
+              
+            <control type="group">
+                <posx>0</posx>
+                <posy>listy</posy>
+                <control type="image">
+                    <visible>!Skin.HasSetting(list.highlight)</visible>
+                    <width>widgethubrightw</width>	
+                    <posx>981</posx>
+                    <height>globalh</height>
+                    <texture border="5" colordiffuse="PosterBorder">common/border-inner.png</texture>
+                </control>
+                <control type="group">
+                    <width>960</width>
+                    <height>globalh</height>
+                    <control type="group">
+                        <posx>globalpad</posx>
+                        <control type="image">
+                            <width>955</width>
+                            <height>globalh</height>
+                            <texture colordiffuse="PosterBorder" border="5">common/border-inner.png</texture>
+                        </control>
+                        
+                        <control type="image">
+                            <left>globalpad</left>
+                            <top>globalpad</top>
+                            <width>269</width>
+                            <height>404</height>
+                            <aspectratio>scale</aspectratio>
+                            <texture background="true">$VAR[PosterImage]</texture>
+                            <fadetime>150</fadetime>
+                        </control>
+                        
+                        <control type="image">
+                            <left>289</left>
+                            <top>globalpad</top>
+                            <right>10</right>
+                            <height>404</height>
+                            <aspectratio>scale</aspectratio>
+                            <texture background="true">$VAR[FanartImage]</texture>
+                            <fadetime>150</fadetime>
+                        </control>
+                        
+                        <control type="grouplist">
+                            <top>424</top>
+                            <left>20</left>
+                            <control type="group">
+                                <height>48</height>
+                                <control type="label">
+                                    <width>825</width>
+                                    <align>left</align>
+                                    <label>$VAR[VARLabel]</label>
+                                </control>
+                                <control type="label">
+                                    <width>915</width>
+                                    <align>right</align>
+                                    <font>Font-ListInfo-Small</font>
+                                    <label>$INFO[ListItem.Label2]</label>
+                                </control>
+                            </control>
+                            <control type="label">
+                                <width>915</width>
+                                <height>48</height>
+                                <aligny>top</aligny>
+                                <font>Font-ListInfo-Small</font>
+                                <label>$VAR[VARLabel3]</label>
+                            </control>
+                            <control type="textbox">
+                                <width>915</width>
+                                <height>130</height>
+                                <align>justify</align>
+                                <font>Font-ListInfo-Small</font>
+                                <label>$VAR[PlotBox]</label>
+                            </control>
+                        </control>
+                        
+        
+                    </control>
+                </control>
+                <control type="list" id="599">				
+                    <posx>981</posx>
+                    <width>widgethubrightw</width>
+                    <height>globalh</height>
+                    <onleft>60</onleft>
+                    <onright>9000</onright>
+                    <onup>599</onup>
+                    <ondown>599</ondown>
+                    <movement>2</movement>
+                    <focusposition>2</focusposition>
+                    <include>DefOnBack</include>
+                    <pagecontrol>60</pagecontrol>
+                    <viewtype label="31281">list</viewtype>
+                    <scrolltime tween="quadratic">400</scrolltime>
+
+                    <itemlayout width="widgethubrightw" height="69">
+                        <control type="group">
+                            <include>599ListContent</include>
+                        </control>
+        
+
+                    </itemlayout>
+
+                    <focusedlayout width="widgethubrightw" height="69">
+                        <control type="group">
+                            <control type="group">
+                                <visible>Control.HasFocus(599)</visible>
+                                <control type="image">
+                                    <width>widgethubrightw</width>
+                                    <height>69</height>
+                                    <texture border="5" colordiffuse="PosterHighlight">common/white.png</texture>
+                                    <visible>!Skin.HasSetting(list.highlight)</visible>
+                                </control>
+                                <control type="group">
+                                    <visible>Skin.HasSetting(list.highlight)</visible>
+                                    <control type="image">
+                                        <width>widgethubrightw</width>
+                                        <height>69</height>
+                                        <texture border="5" colordiffuse="PosterBorder">common/border-inner.png</texture>
+                                    </control>
+                                    <control type="image">
+                                        <width>8</width>
+                                        <height>69</height>
+                                        <texture colordiffuse="PosterHighlight">common/white.png</texture>
+                                    </control>
+                                </control>
+                                <control type="label">
+                                    <left>25</left>
+                                    <right>75</right>
+                                    <textcolor>Selected</textcolor>
+                                    <font>Font-ListInfo</font>
+                                    <label>$VAR[VARLabel]</label>
+                                </control>
+                                <control type="group">
+                                    <posx>56r</posx>
+                                    <posy>8</posy>
+                                    <include>WatchedImage</include>
+                                </control>
+                            </control>
+                            <control type="group">
+                                <visible>!Control.HasFocus(599)</visible>
+                                <include>599ListContent</include>
+                            </control>
+                        </control>
+                    </focusedlayout>
+
+                </control>
+                <control type="scrollbar" id="60">
+                    <posx>969</posx>
+                    <posy>0</posy>
+                    <height>globalh</height>
+                    <include>DefScrollBarMove</include>
+                    <animation effect="fade" start="100" end="25" time="100" condition="!Control.HasFocus(60)">Conditional</animation>
+                    <animation effect="fade" start="100" end="0" condition="ControlGroup(9000).HasFocus()">Conditional</animation>
+                    <animation effect="fade" start="100" end="25" condition="[!IntegerGreaterThan(Container.NumPages,1) + !Control.HasFocus(60)]">Conditional</animation>
+                </control>   
+               
+            </control>
+        </control>
+
+    </include>
+
+</includes>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -723,3 +723,11 @@ msgstr ""
 msgctxt "#31279"
 msgid "Alt style"
 msgstr ""
+
+msgctxt "#31280"
+msgid "Info List (Inv.)"
+msgstr ""
+
+msgctxt "#31281"
+msgid "Media Info (Inv.)"
+msgstr ""


### PR DESCRIPTION
I love both the info and media lists, but for whatever reason, my eyes go crooked because of their (recent?) alignments. To me, it feels much more natural to have the list on top/on right, instead of their current implementations. Otherwise I just keep focusing on the wrong parts of the screen :sweat_smile:

Rather than come complain about it, I decided to give it a go and try to mirror them on my own. Hopefully I haven't forgotten anything.. Still new to understanding how skins exactly work.

I thought I'd share the work. If you like it, feel free to merge it into the main repo. If not, no hard feelings :+1:

If you feel like I should refactor/adjust something before it's acceptable in the main repo, please let me know and I'll gladly make the needed adjustments. 
