### PR TITLE
Fix on-right for scrollbar in favourites dialog

### DIFF
--- a/1080i/DialogFavourites.xml
+++ b/1080i/DialogFavourites.xml
@@ -111,7 +111,7 @@
                     <posx>-8</posx>
                     <posy>listy</posy>
                     <height>globalh</height>
-                    <onright>50</onright>
+                    <onright>450</onright>
                     <animation effect="fade" start="100" end="0" time="400" condition="!Control.HasFocus(60) + !Container.Scrolling">Conditional</animation>
                 </control>
             </control>


### PR DESCRIPTION
When focused on the scrollbar, then pressing 'right' should bring us back to the main favorites panel.